### PR TITLE
feat: atomsWithQuery omit suspense option

### DIFF
--- a/src/atomsWithQuery.ts
+++ b/src/atomsWithQuery.ts
@@ -1,9 +1,9 @@
-import { QueryClient, QueryObserver } from '@tanstack/query-core'
 import type {
   QueryKey,
   QueryObserverOptions,
   QueryObserverResult,
 } from '@tanstack/query-core'
+import { QueryClient, QueryObserver } from '@tanstack/query-core'
 import type { Getter, WritableAtom } from 'jotai'
 import { createAtoms } from './common'
 import { queryClientAtom } from './queryClientAtom'
@@ -23,7 +23,10 @@ export function atomsWithQuery<
 >(
   getOptions: (
     get: Getter
-  ) => QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
+  ) => Omit<
+    QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
+    'suspense'
+  >,
   getQueryClient: (get: Getter) => QueryClient = (get) => get(queryClientAtom)
 ): readonly [
   dataAtom: WritableAtom<TData, Action>,


### PR DESCRIPTION
this PR is related with [jotai/discussion/#1584](https://github.com/pmndrs/jotai/discussions/1584)

As suspense option in tanstck/query is meaning less in jotai-tanstack-query,
this might lead misconceptions using atomsWithQuery.