### PR TITLE
add atomWithQuery.ts

### DIFF
--- a/src/atomWithQuery.ts
+++ b/src/atomWithQuery.ts
@@ -1,0 +1,30 @@
+import { QueryClient, QueryObserver } from '@tanstack/query-core'
+import type { QueryKey, QueryObserverOptions } from '@tanstack/query-core'
+import { type Getter, atom } from 'jotai/vanilla'
+import { queryClientAtom } from './queryClientAtom'
+
+export function atomWithQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  getOptions: (
+    get: Getter
+  ) => QueryObserverOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
+  getQueryClient: (get: Getter) => QueryClient = (get) => get(queryClientAtom)
+) {
+  return atom((get) => {
+    const client = getQueryClient(get)
+    const options = getOptions(get)
+
+    const observer = new QueryObserver(client, options)
+    const defaultedOptions = client.defaultQueryOptions(options)
+
+    const result = observer.getCurrentResult()
+    return defaultedOptions.notifyOnChangeProps
+      ? observer.trackResult(result)
+      : result
+  })
+}


### PR DESCRIPTION
The intention of this PR is for feedback and to guage if this is what is meant by 'overhaul'

I was looking at #42 . I looked at jotai-urql and it looks the the overhaul is to keep the api the same as what urql does?

urql's useQuery returns [data, reexecuteQuery] and so does jotai-urql.

If that's the intention, is this PR inline with what you have in mind for jotai-tanstack-query?

I haven't added things like observerCacheAtom because I haven't fully gone through these patterns. Just wanted to get thoughts on the direction before putting more effort.