### PR TITLE
bug: add default staletime, setOptions when options change in the optionsAtom

### DIFF
--- a/examples/02_typescript_suspense/src/App.tsx
+++ b/examples/02_typescript_suspense/src/App.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, { Suspense } from 'react'
 import { useAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
-import { atomWithQuery } from 'jotai-tanstack-query'
+import { atomWithSuspenseQuery } from 'jotai-tanstack-query'
 
 const idAtom = atom(1)
 
-const userAtom = atomWithQuery<object>((get) => ({
+const userAtom = atomWithSuspenseQuery<object>((get) => ({
   queryKey: ['users', get(idAtom)],
   queryFn: async ({ queryKey: [, id] }) => {
     const res = await fetch(`https://jsonplaceholder.typicode.com/users/${id}`)
@@ -14,10 +14,7 @@ const userAtom = atomWithQuery<object>((get) => ({
 }))
 
 const UserData = () => {
-  const [{ data, isPending, isError }] = useAtom(userAtom)
-
-  if (isPending) return <div>Loading...</div>
-  if (isError) return <div>Error</div>
+  const [{ data }] = useAtom(userAtom)
 
   return <div>{JSON.stringify(data)}</div>
 }
@@ -40,7 +37,9 @@ const Controls = () => {
 const App = () => (
   <>
     <Controls />
-    <UserData />
+    <Suspense fallback="loading">
+      <UserData />
+    </Suspense>
   </>
 )
 

--- a/src/baseAtomWithQuery.ts
+++ b/src/baseAtomWithQuery.ts
@@ -139,7 +139,6 @@ export function baseAtomWithQuery<
   ) => QueryObserver<TQueryFnData, TError, TData, TQueryData, TQueryKey>,
   getQueryClient: (get: Getter) => QueryClient = (get) => get(queryClientAtom)
 ) {
-  const IN_RENDER = Symbol()
   const resetAtom = atom(0)
   if (process.env.NODE_ENV !== 'production') {
     resetAtom.debugPrivate = true
@@ -149,13 +148,7 @@ export function baseAtomWithQuery<
     const observer = getObserver(get)
     const source = make<QueryObserverResult<TData, TError>>(({ next }) => {
       const callback = (result: QueryObserverResult<TData, TError>) => {
-        const notifyResult = () => next(result)
-
-        if ((observer as any)[IN_RENDER]) {
-          Promise.resolve().then(notifyResult)
-        } else {
-          notifyResult()
-        }
+        next(result)
       }
 
       return observer.subscribe(callback)
@@ -204,12 +197,11 @@ export function baseAtomWithQuery<
     }
 
     get(resetAtom)
-    const resultAtom = get(dataAtom)
-    const result = get(resultAtom)
+    get(get(dataAtom))
 
-    const optimisticResult = observer.getOptimisticResult(options)
+    const result = observer.getOptimisticResult(options)
 
-    if (shouldSuspend(options, optimisticResult, false)) {
+    if (shouldSuspend(options, result, false)) {
       return observer.fetchOptimistic(options)
     }
 


### PR DESCRIPTION
fixes #58 

code cleanup: move setOptions to optionsAtom. this would be triggered only if there's an observer in cache. if not, a new observer has to be created with the new options, no need to setOptions here.