### PR TITLE
fix: unsubscribe needs to be called

### DIFF
--- a/src/atomWithMutation.ts
+++ b/src/atomWithMutation.ts
@@ -77,7 +77,7 @@ export function atomWithMutation<
         set(state)
       })
       return () => {
-        unsubscribe
+        unsubscribe()
         observer.reset()
       }
     }


### PR DESCRIPTION
The unsubscribe function should either be called or removed since it is immediately followed by a reset of the observer which runs `removeObserver` without the `hasListeners` guard of `unsubscribe`.

Arguably it is better to only call `unsubscribe` and remove the `reset`. Can update the PR if you agree