### PR TITLE
refresh setter to reset error boundary

### DIFF
--- a/src/atomWithInfiniteQuery.ts
+++ b/src/atomWithInfiniteQuery.ts
@@ -6,7 +6,7 @@ import {
   QueryKey,
   QueryObserver,
 } from '@tanstack/query-core'
-import { Atom, Getter } from 'jotai'
+import { Getter, WritableAtom } from 'jotai'
 import { baseAtomWithQuery } from './baseAtomWithQuery'
 import { queryClientAtom } from './queryClientAtom'
 import {
@@ -34,7 +34,7 @@ export function atomWithInfiniteQuery<
     TPageParam
   >,
   getQueryClient?: (get: Getter) => QueryClient
-): Atom<AtomWithInfiniteQueryResult<TData, TError>>
+): WritableAtom<AtomWithInfiniteQueryResult<TData, TError>, [], void>
 export function atomWithInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,
@@ -52,7 +52,7 @@ export function atomWithInfiniteQuery<
     TPageParam
   >,
   getQueryClient?: (get: Getter) => QueryClient
-): Atom<DefinedAtomWithInfiniteQueryResult<TData, TError>>
+): WritableAtom<DefinedAtomWithInfiniteQueryResult<TData, TError>, [], void>
 export function atomWithInfiniteQuery<
   TQueryFnData,
   TError = DefaultError,
@@ -71,7 +71,7 @@ export function atomWithInfiniteQuery<
     TPageParam
   >,
   getQueryClient?: (get: Getter) => QueryClient
-): Atom<AtomWithInfiniteQueryResult<TData, TError>>
+): WritableAtom<AtomWithInfiniteQueryResult<TData, TError>, [], void>
 export function atomWithInfiniteQuery(
   getOptions: (get: Getter) => AtomWithInfiniteQueryOptions,
   getQueryClient: (get: Getter) => QueryClient = (get) => get(queryClientAtom)

--- a/src/atomWithQuery.ts
+++ b/src/atomWithQuery.ts
@@ -4,7 +4,7 @@ import {
   QueryKey,
   QueryObserver,
 } from '@tanstack/query-core'
-import { Atom, Getter } from 'jotai'
+import { Getter, WritableAtom } from 'jotai'
 import { baseAtomWithQuery } from './baseAtomWithQuery'
 import { queryClientAtom } from './queryClientAtom'
 import {
@@ -25,7 +25,7 @@ export function atomWithQuery<
     get: Getter
   ) => UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   getQueryClient?: (get: Getter) => QueryClient
-): Atom<AtomWithQueryResult<TData, TError>>
+): WritableAtom<AtomWithQueryResult<TData, TError>, [], void>
 export function atomWithQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -36,7 +36,7 @@ export function atomWithQuery<
     get: Getter
   ) => DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
   getQueryClient?: (get: Getter) => QueryClient
-): Atom<DefinedAtomWithQueryResult<TData, TError>>
+): WritableAtom<DefinedAtomWithQueryResult<TData, TError>, [], void>
 export function atomWithQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
@@ -47,7 +47,7 @@ export function atomWithQuery<
     get: Getter
   ) => AtomWithQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   getQueryClient?: (get: Getter) => QueryClient
-): Atom<AtomWithQueryResult<TData, TError>>
+): WritableAtom<AtomWithQueryResult<TData, TError>, [], void>
 export function atomWithQuery(
   getOptions: (get: Getter) => AtomWithQueryOptions,
   getQueryClient: (get: Getter) => QueryClient = (get) => get(queryClientAtom)

--- a/src/atomWithSuspenseInfiniteQuery.ts
+++ b/src/atomWithSuspenseInfiniteQuery.ts
@@ -6,7 +6,7 @@ import {
   QueryKey,
   QueryObserver,
 } from '@tanstack/query-core'
-import { Atom, Getter, atom } from 'jotai'
+import { Getter, WritableAtom, atom } from 'jotai'
 import { baseAtomWithQuery } from './baseAtomWithQuery'
 import { queryClientAtom } from './queryClientAtom'
 import {
@@ -33,7 +33,7 @@ export function atomWithSuspenseInfiniteQuery<
     TPageParam
   >,
   getQueryClient: (get: Getter) => QueryClient = (get) => get(queryClientAtom)
-): Atom<AtomWithSuspenseInfiniteQueryResult<TData, TError>> {
+): WritableAtom<AtomWithSuspenseInfiniteQueryResult<TData, TError>, [], void> {
   const suspenseOptionsAtom = atom((get) => {
     const options = getOptions(get)
     return {
@@ -48,5 +48,9 @@ export function atomWithSuspenseInfiniteQuery<
     (get: Getter) => get(suspenseOptionsAtom),
     InfiniteQueryObserver as typeof QueryObserver,
     getQueryClient
-  ) as unknown as Atom<AtomWithSuspenseInfiniteQueryResult<TData, TError>>
+  ) as unknown as WritableAtom<
+    AtomWithSuspenseInfiniteQueryResult<TData, TError>,
+    [],
+    void
+  >
 }

--- a/src/atomWithSuspenseQuery.ts
+++ b/src/atomWithSuspenseQuery.ts
@@ -4,7 +4,7 @@ import {
   QueryKey,
   QueryObserver,
 } from '@tanstack/query-core'
-import { Atom, Getter, atom } from 'jotai'
+import { Getter, WritableAtom, atom } from 'jotai'
 import { baseAtomWithQuery } from './baseAtomWithQuery'
 import { queryClientAtom } from './queryClientAtom'
 import {
@@ -23,7 +23,7 @@ export function atomWithSuspenseQuery<
     get: Getter
   ) => AtomWithSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   getQueryClient: (get: Getter) => QueryClient = (get) => get(queryClientAtom)
-): Atom<AtomWithSuspenseQueryResult<TData, TError>> {
+): WritableAtom<AtomWithSuspenseQueryResult<TData, TError>, [], void> {
   const suspenseOptions = atom((get) => {
     const options = getOptions(get)
     return {
@@ -38,5 +38,5 @@ export function atomWithSuspenseQuery<
     (get: Getter) => get(suspenseOptions),
     QueryObserver,
     getQueryClient
-  ) as Atom<AtomWithSuspenseQueryResult<TData, TError>>
+  ) as WritableAtom<AtomWithSuspenseQueryResult<TData, TError>, [], void>
 }


### PR DESCRIPTION
solves #32, #72

Error is a valid value that an atom can hold. So we need to force the atom to re-evaluate while resetting the error boundary for the fetch to happen again.

@dai-shi Do you have a preference for versioning this? We are changing the signature of the atom to return a WritableAtom to expose a setter which resets the error boundary. My preference is to bump the minor version instead of the patch version. What do you think?

Tangent: Should error be considered a valid value in jotai when checking if the atom should recompute? 