### PR TITLE
Added jotai-query Ssr

### DIFF
--- a/examples/10_jotai-query-ssr/README.md
+++ b/examples/10_jotai-query-ssr/README.md
@@ -1,0 +1,104 @@
+# Jotai + TanStack Query SSR Example
+
+This example demonstrates how to use [Jotai](https://jotai.org/) with [TanStack Query](https://tanstack.com/query) for Server-Side Rendering (SSR) in a Next.js App Router application.
+
+
+## Getting Started
+
+### Installation
+
+```bash
+npm install
+# or
+yarn install
+# or
+pnpm install
+```
+
+### Run Development Server
+
+```bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+### Build for Production
+
+```bash
+npm run build
+npm start
+```
+
+## How It Works
+
+### 1. Server Component Prefetching (`app/page.tsx`)
+
+The server component prefetches data using TanStack Query's `QueryClient`:
+
+```typescript
+async function getDehydratedState() {
+  const queryClient = new QueryClient()
+  
+  await queryClient.prefetchQuery({
+    queryKey: ['user'],
+    queryFn: async () => {
+      const res = await fetch('https://jsonplaceholder.typicode.com/users/1')
+      return res.json()
+    },
+  })
+  
+  return dehydrate(queryClient)
+}
+```
+
+### 2. Jotai Atom with TanStack Query (`atoms/userAtom.ts`)
+
+The atom is created using `atomWithQuery` from `jotai-tanstack-query`:
+
+```typescript
+export const userAtom = atomWithQuery(() => ({
+  queryKey: ['user'],
+  queryFn: async () => {
+    const res = await fetch('https://jsonplaceholder.typicode.com/users/1')
+    return res.json()
+  },
+}))
+```
+
+### 3. Provider Setup (`app/providers.tsx`)
+
+Both QueryClientProvider and JotaiProvider wrap the application:
+
+```typescript
+<QueryClientProvider client={queryClient}>
+  <JotaiProvider>{children}</JotaiProvider>
+</QueryClientProvider>
+```
+
+### 4. Client Component Consumption (`app/user-client.tsx`)
+
+The client component reads from the Jotai atom, which automatically uses the hydrated TanStack Query data:
+
+```typescript
+const [{data}] = useAtom(userAtom)
+```
+For additional parameters
+```typescript
+const [{ data, isLoading, error}] = useAtom(userAtom)
+```
+
+
+### SSR Flow
+
+1. **Server**: Next.js server component prefetches data using TanStack Query
+2. **Server**: Data is dehydrated and passed to `HydrationBoundary`
+3. **Client**: QueryClient hydrates the prefetched data
+4. **Client**: Jotai atom (via `atomWithQuery`) reads from the hydrated TanStack Query cache
+5. **Result**: No loading state, data is immediately available on first render
+
+

--- a/examples/10_jotai-query-ssr/README.md
+++ b/examples/10_jotai-query-ssr/README.md
@@ -97,8 +97,9 @@ const [{ data, isLoading, error}] = useAtom(userAtom)
 
 1. **Server**: Next.js server component prefetches data using TanStack Query
 2. **Server**: Data is dehydrated and passed to `HydrationBoundary`
-3. **Client**: QueryClient hydrates the prefetched data
-4. **Client**: Jotai atom (via `atomWithQuery`) reads from the hydrated TanStack Query cache
-5. **Result**: No loading state, data is immediately available on first render
+3. **Client**: `HydrationBoundary` hydrates the QueryClient with prefetched data
+4. **Client**: `useHydrateAtoms` syncs the QueryClient with jotai-tanstack-query's `queryClientAtom`
+5. **Client**: Jotai atom (via `atomWithQuery`) reads from the merged QueryClient cache
+6. **Result**: No loading state, data is immediately available on first render
 
 

--- a/examples/10_jotai-query-ssr/next.config.ts
+++ b/examples/10_jotai-query-ssr/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  /* config options here */
+};
+
+export default nextConfig;

--- a/examples/10_jotai-query-ssr/package.json
+++ b/examples/10_jotai-query-ssr/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "jotai-query-ssr-example",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "dev": "next dev",
+        "build": "next build",
+        "start": "next start",
+        "lint": "eslint"
+    },
+    "dependencies": {
+        "@tanstack/react-query": "^5.90.10",
+        "jotai": "^2.15.1",
+        "jotai-tanstack-query": "^0.11.0",
+        "next": "16.0.3",
+        "react": "19.2.0",
+        "react-dom": "19.2.0"
+    },
+    "devDependencies": {
+        "@types/node": "^20",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "eslint": "^9",
+        "eslint-config-next": "16.0.3",
+        "tailwindcss": "^4",
+        "typescript": "^5"
+    }
+}

--- a/examples/10_jotai-query-ssr/src/app/layout.tsx
+++ b/examples/10_jotai-query-ssr/src/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import AppProviders from "./providers";
+
+
+export const metadata: Metadata = {
+  title: "Jotai + Tanstack Query SSR Example",
+};
+
+export default function RootLayout({
+  children,
+}:{
+  children: React.ReactNode;
+}) {
+  return (
+     <html lang="en">
+      <body>
+        <AppProviders>{children}</AppProviders>
+      </body>
+    </html>
+  );
+}
+

--- a/examples/10_jotai-query-ssr/src/app/page.tsx
+++ b/examples/10_jotai-query-ssr/src/app/page.tsx
@@ -1,0 +1,31 @@
+import { HydrationBoundary, dehydrate, QueryClient } from '@tanstack/react-query'
+import UserClient from './user-client'
+
+// This runs on the server
+async function getDehydratedState() {
+  const queryClient = new QueryClient()
+
+  // Prefetch the same query used by our Jotai atom
+  await queryClient.prefetchQuery({
+    queryKey: ['user'],
+    queryFn: async () => {
+      const res = await fetch('https://jsonplaceholder.typicode.com/users/1')
+      return res.json()
+    },
+  })
+
+  return dehydrate(queryClient)
+}
+
+export default async function Page() {
+  const dehydratedState = await getDehydratedState()
+
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      {/* Client Component that reads from Jotai atom */}
+      <UserClient />
+    </HydrationBoundary>
+  )
+}
+
+

--- a/examples/10_jotai-query-ssr/src/app/providers.tsx
+++ b/examples/10_jotai-query-ssr/src/app/providers.tsx
@@ -3,15 +3,27 @@
 import { PropsWithChildren, useState } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Provider as JotaiProvider } from 'jotai'
+import { useHydrateAtoms } from 'jotai/react/utils'
+import { queryClientAtom } from 'jotai-tanstack-query'
 
 export default function AppProviders({ children }: PropsWithChildren) {
   const [queryClient] = useState(() => new QueryClient())
 
   return (
     <QueryClientProvider client={queryClient}>
-      <JotaiProvider>{children}</JotaiProvider>
+      <JotaiProvider>
+        <HydrateAtoms queryClient={queryClient}>
+          {children}
+        </HydrateAtoms>
+      </JotaiProvider>
     </QueryClientProvider>
   )
 }
 
-
+const HydrateAtoms = ({ 
+  children, 
+  queryClient 
+}: PropsWithChildren<{ queryClient: QueryClient }>) => {
+  useHydrateAtoms([[queryClientAtom, queryClient]])
+  return children
+}

--- a/examples/10_jotai-query-ssr/src/app/providers.tsx
+++ b/examples/10_jotai-query-ssr/src/app/providers.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { PropsWithChildren, useState } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Provider as JotaiProvider } from 'jotai'
+
+export default function AppProviders({ children }: PropsWithChildren) {
+  const [queryClient] = useState(() => new QueryClient())
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <JotaiProvider>{children}</JotaiProvider>
+    </QueryClientProvider>
+  )
+}
+
+

--- a/examples/10_jotai-query-ssr/src/app/user-client.tsx
+++ b/examples/10_jotai-query-ssr/src/app/user-client.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useAtom } from 'jotai'
+import { userAtom } from '../atoms/userAtom'
+
+export default function UserClient() {
+  const [{data}] = useAtom(userAtom)
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>SSR with Jotai + TanStack Query</h1>
+      <p>
+        <strong>Name:</strong> {data?.name}
+      </p>
+      <p>
+        <strong>Email:</strong> {data?.email}
+      </p>
+      <p>
+        <strong>Website:</strong> {data?.website}
+      </p>
+    </div>
+  )
+}
+

--- a/examples/10_jotai-query-ssr/src/atoms/userAtom.ts
+++ b/examples/10_jotai-query-ssr/src/atoms/userAtom.ts
@@ -1,0 +1,13 @@
+import { atomWithQuery } from 'jotai-tanstack-query'
+
+export const userAtom = atomWithQuery(() => ({
+  queryKey: ['user'],
+  queryFn: async () => {
+    const res = await fetch(
+      'https://jsonplaceholder.typicode.com/users/1'
+    )
+    return res.json()
+  },
+}))
+
+

--- a/examples/10_jotai-query-ssr/tsconfig.json
+++ b/examples/10_jotai-query-ssr/tsconfig.json
@@ -1,0 +1,42 @@
+{
+    "compilerOptions": {
+        "target": "ES2017",
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "esnext"
+        ],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "noEmit": true,
+        "esModuleInterop": true,
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "jsx": "react-jsx",
+        "incremental": true,
+        "plugins": [
+            {
+                "name": "next"
+            }
+        ],
+        "paths": {
+            "@/*": [
+                "./*"
+            ]
+        }
+    },
+    "include": [
+        "next-env.d.ts",
+        "**/*.ts",
+        "**/*.tsx",
+        ".next/types/**/*.ts",
+        ".next/dev/types/**/*.ts",
+        "**/*.mts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}


### PR DESCRIPTION
Yo guys, Added the basic use case for SSR data fetching with TanStack Query + Jotai in Next.js.
Data is prefetched on the server, hydrated on the client, and consumed via Jotai’s atomWithQuery