### PR TITLE
Fix observer remount after query garbage collection

### DIFF
--- a/__tests__/atomWithQuery.spec.tsx
+++ b/__tests__/atomWithQuery.spec.tsx
@@ -1,6 +1,6 @@
 import React, { StrictMode, Suspense, useState } from 'react'
 import { QueryClient } from '@tanstack/query-core'
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, waitFor } from '@testing-library/react'
 import { Getter, atom, useAtom, useSetAtom } from 'jotai'
 import { unwrap } from 'jotai/utils'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -527,6 +527,56 @@ it('query expected QueryCache test', async () => {
   resolve()
   await findByText('count: 0')
   expect(queryClient.getQueryCache().getAll().length).toBe(1)
+})
+
+it('reconnects to the live query after gc', async () => {
+  const queryClient = new QueryClient()
+  const valueAtom = atomWithQuery(
+    () => ({
+      gcTime: 0,
+      queryKey: ['reconnect-after-gc'],
+      queryFn: async () => 'initial',
+      staleTime: Infinity,
+    }),
+    () => queryClient
+  )
+  const Value = () => {
+    const [{ data }] = useAtom(valueAtom)
+
+    return <div>value: {data ?? 'pending'}</div>
+  }
+
+  const { findByText, rerender } = render(<Value />)
+
+  await findByText('value: initial')
+
+  rerender(<></>)
+
+  await waitFor(() => {
+    expect(
+      queryClient.getQueryCache().find({
+        exact: true,
+        queryKey: ['reconnect-after-gc'],
+      })
+    ).toBeUndefined()
+  })
+
+  queryClient.setQueryData(['reconnect-after-gc'], 'after gc')
+  rerender(<Value />)
+
+  await findByText('value: after gc')
+  expect(
+    queryClient
+      .getQueryCache()
+      .find({
+        exact: true,
+        queryKey: ['reconnect-after-gc'],
+      })
+      ?.getObserversCount()
+  ).toBe(1)
+
+  queryClient.setQueryData(['reconnect-after-gc'], 'second update after gc')
+  await findByText('value: second update after gc')
 })
 
 describe('error handling', () => {

--- a/src/baseAtomWithQuery.ts
+++ b/src/baseAtomWithQuery.ts
@@ -91,6 +91,7 @@ export function baseAtomWithQuery<
   }
 
   const dataAtom = atom((get) => {
+    const client = get(clientAtom)
     const observer = get(observerAtom)
     const defaultedOptions = get(defaultedOptionsAtom)
     const result = observer.getOptimisticResult(defaultedOptions)
@@ -101,6 +102,17 @@ export function baseAtomWithQuery<
     }
 
     resultAtom.onMount = (set) => {
+      const currentQuery = observer.getCurrentQuery()
+      const cachedQuery = client.getQueryCache().find({
+        exact: true,
+        queryKey: currentQuery.queryKey,
+      })
+
+      if (cachedQuery !== currentQuery) {
+        observer.setOptions(defaultedOptions)
+        set(observer.getCurrentResult())
+      }
+
       const unsubscribe = observer.subscribe(notifyManager.batchCalls(set))
       return () => {
         if (observer.getCurrentResult().isError) {


### PR DESCRIPTION
## Summary

- Reconnect a cached observer only when it still points at a query object that TanStack Query already removed
- Refresh the mounted result atom from the observer before subscribing again in that dead-query case
- Add a regression test for remounting after TanStack Query garbage-collects an inactive query

## Why

`atomWithQuery` keeps a `QueryObserver` cached for a given `QueryClient`. TanStack Query, however, is allowed to garbage-collect inactive query objects after `gcTime`. That means this sequence can happen:

1. An atom mounts and its observer points at query object A
2. The atom unmounts, query A becomes inactive, and TanStack Query garbage-collects it
3. The atom mounts again later with the same query key
4. TanStack Query creates a new live query object B for that key, but the cached observer still points at the old removed query A

At that point, future cache writes go to query B, while the Jotai atom keeps reading the stale result from query A. From the app's point of view, the TanStack cache is up to date but the atom never changes again.

On remount, the observer only needs repair if its current query object is no longer the live query object in the cache for that key. In that case, `observer.setOptions(defaultedOptions)` makes the cached observer reconnect to the current live query, and refreshing the result atom with `observer.getCurrentResult()` ensures the remount immediately reflects the live cache value instead of the old pre-GC snapshot.

Checking for that dead-query case keeps ordinary remount behavior unchanged while still fixing the stale observer after GC.

The new test reproduces this with `gcTime: 0`: mount, unmount until the query is collected, write fresh data for the same key, remount, and verify that the atom reads and continues following the live query again.

## Validation

- `pnpm test`

Fixes #83
