### PR TITLE
fix: rebind query observers after cache replacement

### DIFF
--- a/__tests__/atomWithQuery.spec.tsx
+++ b/__tests__/atomWithQuery.spec.tsx
@@ -1,7 +1,7 @@
 import React, { StrictMode, Suspense, useState } from 'react'
 import { QueryClient } from '@tanstack/query-core'
 import { fireEvent, render } from '@testing-library/react'
-import { Getter, atom, useAtom, useSetAtom } from 'jotai'
+import { Getter, atom, createStore, useAtom, useSetAtom } from 'jotai'
 import { unwrap } from 'jotai/utils'
 import { ErrorBoundary } from 'react-error-boundary'
 import { vi } from 'vitest'
@@ -767,4 +767,134 @@ it(`ensure that setQueryData for an inactive query updates its atom state`, asyn
   fireEvent.click(await findByText('Set page 1'))
   await expect(() => findByText('loading')).rejects.toThrow()
   await findByText('Name: Alex Smith')
+})
+
+it('rebinds a cached observer when remounted after queryClient.clear()', async () => {
+  const queryClient = new QueryClient()
+  const queryKey = ['profile-after-remount']
+  queryClient.setQueryData(queryKey, 'A')
+
+  const profileAtom = atomWithQuery(
+    () => ({
+      queryKey,
+      queryFn: async () => 'B',
+      staleTime: Infinity,
+    }),
+    () => queryClient
+  )
+  const store = createStore()
+  const unsubscribe = store.sub(profileAtom, () => {})
+
+  expect(store.get(profileAtom).data).toBe('A')
+
+  queryClient.setQueryData(queryKey, 'A2')
+  unsubscribe()
+  queryClient.clear()
+  queryClient.setQueryData(queryKey, 'B')
+
+  const unsubscribeAgain = store.sub(profileAtom, () => {})
+
+  expect(store.get(profileAtom).data).toBe('B')
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 0))
+  expect(store.get(profileAtom).data).toBe('B')
+
+  unsubscribeAgain()
+  queryClient.clear()
+})
+
+it('observes a replacement query created during the initial subscription', async () => {
+  const queryClient = new QueryClient()
+  const queryKey = ['profile-during-subscription']
+  queryClient.setQueryData(queryKey, 'A')
+  await queryClient.invalidateQueries({ queryKey })
+
+  let replaced = false
+  const queryFn = vi.fn(async () => {
+    if (!replaced) {
+      replaced = true
+      queryClient.clear()
+      queryClient.setQueryData(queryKey, 'B')
+      queryClient.setQueryData(queryKey, 'C')
+    }
+    return 'old query result'
+  })
+  const profileAtom = atomWithQuery(
+    () => ({ queryKey, queryFn, staleTime: Infinity }),
+    () => queryClient
+  )
+  const store = createStore()
+  const unsubscribe = store.sub(profileAtom, () => {})
+
+  await vi.waitFor(() => expect(store.get(profileAtom).data).toBe('C'))
+  expect(queryFn).toHaveBeenCalledTimes(1)
+
+  unsubscribe()
+  queryClient.clear()
+})
+
+it('reuses a replacement query fetch with the default staleTime', async () => {
+  const queryClient = new QueryClient()
+  const queryKey = ['profile-replacement-fetch']
+
+  const queryFn = vi.fn(async () => 'A')
+  const replacementQueryFn = vi.fn(async () => 'B')
+  const profileAtom = atomWithQuery(
+    () => ({ queryKey, queryFn }),
+    () => queryClient
+  )
+  const store = createStore()
+  const unsubscribe = store.sub(profileAtom, () => {})
+
+  await vi.waitFor(() => expect(store.get(profileAtom).data).toBe('A'))
+  queryFn.mockClear()
+
+  queryClient.clear()
+  expect(queryClient.getQueryCache().find({ queryKey })).toBeUndefined()
+
+  await queryClient.fetchQuery({ queryKey, queryFn: replacementQueryFn })
+  await vi.waitFor(() => expect(store.get(profileAtom).data).toBe('B'))
+  await new Promise((resolve) => globalThis.setTimeout(resolve, 0))
+
+  expect(store.get(profileAtom).data).toBe('B')
+  expect(replacementQueryFn).toHaveBeenCalledTimes(1)
+  expect(queryFn).not.toHaveBeenCalled()
+
+  unsubscribe()
+  queryClient.clear()
+})
+
+it('shares one QueryCache subscription between mounted query atoms', () => {
+  const queryClient = new QueryClient()
+  const subscribe = vi.spyOn(queryClient.getQueryCache(), 'subscribe')
+  const firstAtom = atomWithQuery(
+    () => ({
+      queryKey: ['first-shared-subscription'],
+      queryFn: async () => 'first',
+    }),
+    () => queryClient
+  )
+  const secondAtom = atomWithQuery(
+    () => ({
+      queryKey: ['second-shared-subscription'],
+      queryFn: async () => 'second',
+    }),
+    () => queryClient
+  )
+  const store = createStore()
+
+  const unsubscribeFirst = store.sub(firstAtom, () => {})
+  const unsubscribeSecond = store.sub(secondAtom, () => {})
+
+  expect(subscribe).toHaveBeenCalledTimes(1)
+
+  unsubscribeFirst()
+  unsubscribeSecond()
+
+  const unsubscribeAgain = store.sub(firstAtom, () => {})
+
+  expect(subscribe).toHaveBeenCalledTimes(2)
+
+  unsubscribeAgain()
+  queryClient.clear()
+  subscribe.mockRestore()
 })

--- a/src/baseAtomWithQuery.ts
+++ b/src/baseAtomWithQuery.ts
@@ -1,4 +1,6 @@
 import {
+  type Query,
+  type QueryCache,
   QueryClient,
   type QueryKey,
   QueryObserver,
@@ -9,6 +11,73 @@ import { Getter, WritableAtom, atom } from 'jotai'
 import { queryClientAtom } from './_queryClientAtom'
 import { BaseAtomWithQueryOptions } from './types'
 import { ensureStaleTime, getHasError, shouldSuspend } from './utils'
+
+type QueryAddedListener = (query: Query) => void
+
+type QueryCacheSubscription = {
+  listenersByQueryHash: Map<string, Set<QueryAddedListener>>
+  unsubscribe: () => void
+}
+
+const queryCacheSubscriptions = new WeakMap<
+  QueryCache,
+  QueryCacheSubscription
+>()
+
+const subscribeToQueryAdded = (
+  queryCache: QueryCache,
+  queryHash: string,
+  listener: QueryAddedListener
+) => {
+  let subscription = queryCacheSubscriptions.get(queryCache)
+
+  if (!subscription) {
+    const listenersByQueryHash = new Map<
+      string,
+      Set<QueryAddedListener>
+    >()
+    const notify = (query: Query) => {
+      if (queryCache.get(query.queryHash) !== query) return
+      listenersByQueryHash
+        .get(query.queryHash)
+        ?.forEach((listener) => listener(query))
+    }
+
+    subscription = {
+      listenersByQueryHash,
+      unsubscribe: queryCache.subscribe((event) => {
+        if (event.type === 'added') {
+          void Promise.resolve().then(() => notify(event.query))
+        }
+      }),
+    }
+    queryCacheSubscriptions.set(queryCache, subscription)
+  }
+
+  let listeners = subscription.listenersByQueryHash.get(queryHash)
+  if (!listeners) {
+    listeners = new Set()
+    subscription.listenersByQueryHash.set(queryHash, listeners)
+  }
+  listeners.add(listener)
+
+  let isSubscribed = true
+  return () => {
+    if (!isSubscribed) return
+    isSubscribed = false
+    listeners.delete(listener)
+
+    if (!listeners.size) {
+      subscription.listenersByQueryHash.delete(queryHash)
+    }
+    if (!subscription.listenersByQueryHash.size) {
+      subscription.unsubscribe()
+      if (queryCacheSubscriptions.get(queryCache) === subscription) {
+        queryCacheSubscriptions.delete(queryCache)
+      }
+    }
+  }
+}
 
 export function baseAtomWithQuery<
   TQueryFnData,
@@ -91,6 +160,7 @@ export function baseAtomWithQuery<
   }
 
   const dataAtom = atom((get) => {
+    const client = get(clientAtom)
     const observer = get(observerAtom)
     const defaultedOptions = get(defaultedOptionsAtom)
     const result = observer.getOptimisticResult(defaultedOptions)
@@ -100,13 +170,40 @@ export function baseAtomWithQuery<
       resultAtom.debugPrivate = true
     }
 
+    let mountGeneration = 0
     resultAtom.onMount = (set) => {
-      const unsubscribe = observer.subscribe(notifyManager.batchCalls(set))
+      const generation = ++mountGeneration
+      observer.setOptions(defaultedOptions)
+      let isMounted = true
+      const queryCache = client.getQueryCache()
+      const unsubscribeCache = subscribeToQueryAdded(
+        queryCache,
+        observer.getCurrentQuery().queryHash,
+        (query) => {
+          if (
+            isMounted &&
+            queryCache.get(query.queryHash) === query &&
+            query.queryHash === observer.options.queryHash &&
+            query !== observer.getCurrentQuery()
+          ) {
+            observer.setOptions(observer.options)
+          }
+        }
+      )
+      const unsubscribeObserver = observer.subscribe(
+        notifyManager.batchCalls((result) => {
+          if (generation === mountGeneration) set(result)
+        })
+      )
+      set(observer.getCurrentResult())
+
       return () => {
+        isMounted = false
+        unsubscribeCache()
         if (observer.getCurrentResult().isError) {
           observer.getCurrentQuery().reset()
         }
-        unsubscribe()
+        unsubscribeObserver()
       }
     }
 


### PR DESCRIPTION
## Summary

- reconcile cached query observers with the current query when an atom mounts
- rebind mounted observers when a same-hash replacement query is added to the cache
- share one QueryCache listener per cache and dispatch replacement queries by hash
- ignore queued observer results from a superseded mount generation
- cover remount, synchronous subscription, and in-flight replacement fetch behavior

## Root cause

QueryClient.clear() removes and destroys cached Query instances, but a cached QueryObserver can remain attached to the removed query. When the same query key is fetched again, Query Core creates a replacement Query, while the atom can continue exposing the old observer result.

The shared cache listener is registered before observer.subscribe() so it cannot miss a replacement created by a synchronous queryFn. It reacts only to added queries and reconciles in a microtask: QueryClient.fetchQuery() has created its retryer by then, but the request has not completed, so QueryObserver reuses the in-flight fetch instead of starting the atom queryFn again.

Observer notifications scheduled by a previous mount are generation-checked before updating the result atom, so they cannot overwrite the result established by a later remount.

## Impact

Atoms now follow replacement queries after clear() without requiring a new QueryClient or Jotai store. Cached observers also reconcile when remounted, and mounted atoms do not add one global QueryCache listener each.

## Validation

- pnpm test
  - ESLint passed
  - TypeScript passed
  - 7 test files and 37 tests passed
